### PR TITLE
Update for Grunt 1, QUnit 2, and jQuery 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - "5.4.1"
-before_script:
-  - npm install -g grunt-cli
+  - "14"
+  - "12"
+  - "10"

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,11 +13,12 @@ module.exports = function(grunt) {
       all: ["*.js", "test/**/*.js"]
     },
     qunit: {
+      // For CI and Docker compat
+      options: { puppeteer: { args: [ "--no-sandbox" ] } },
       all: ["test/index.html"]
     }
   });
 
   grunt.registerTask("test", ["jshint", "qunit"]);
-  grunt.registerTask("default", ["test"]);
 
 };

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Where batch is an array of assertion request objects, each of the following stru
 ### Example ###
 
 ```js
-test( "Components availability", function( assert ) {
+QUnit.test( "Components availability", function( assert ) {
     assert.nodes([
         {node: $("section.example"),
             assert: "exists",

--- a/package.json
+++ b/package.json
@@ -27,10 +27,11 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt": "~0.4.1",
-    "grunt-contrib-jshint": "~0.4.3",
-    "grunt-contrib-qunit": "~0.2.1",
-    "grunt-git-authors": "~1.2.0",
-    "qunitjs": "1.x"
+    "grunt": "~1.3.0",
+    "grunt-contrib-jshint": "~2.1.0",
+    "grunt-contrib-qunit": "~4.0.0",
+    "grunt-git-authors": "~3.2.0",
+    "jquery": "~3.5.1",
+    "qunit": "~2.10.0"
   }
 }

--- a/qunit-assert-nodes.js
+++ b/qunit-assert-nodes.js
@@ -57,13 +57,13 @@
          */
         nodes: function( batch ) {
             var that = this;
-            if ( !$.isArray( batch ) ) {
-                    throw new TypeError("query parameter must be an array");
+            if ( !Array.isArray( batch ) ) {
+                throw new TypeError("query parameter must be an array");
             }
-            $.each( batch, function( i ){
-                if ( !batch[ i ].node || !batch[ i ].assert ) {
+            $.each( batch, function( i, request ) {
+                if ( !request.node || !request.assert ) {
                     throw new TypeError("query element is invalid. Must be { node: '', assert: '', message: ''}");
-            }
+                }
             });
             $.each( batch, function( inx, request ) {
                 that.ok( assertions[ request.assert ].call( request.node ), request.message );

--- a/test/index.html
+++ b/test/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <title>qunit-assert-nodes plugin tests</title>
-  <link rel="stylesheet" href="../node_modules/qunitjs/qunit/qunit.css">
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js" type="text/javascript"></script>
-  <script src="../node_modules/qunitjs/qunit/qunit.js"></script>
+  <link rel="stylesheet" href="../node_modules/qunit/qunit/qunit.css">
+  <script src="../node_modules/jquery/dist/jquery.min.js"></script>
+  <script src="../node_modules/qunit/qunit/qunit.js"></script>
   <script src="../qunit-assert-nodes.js"></script>
   <script src="nodes-test.js"></script>
 </head>

--- a/test/nodes-test.js
+++ b/test/nodes-test.js
@@ -1,12 +1,12 @@
 QUnit.module("Test qunit-assert-nodes assertion methods", {
-    setup: function() {
+    beforeEach: function() {
         this.fixture = $('<div id="fixture" style="visibility: hidden">' +
             '<div id="case1"></div>' +
             '<div id="case2" style="display: none"></div>' +
             '<input id="case3" type="checkbox" checked="checked" />' +
             '</div>').appendTo("body");
     },
-    teardown: function() {
+    afterEach: function() {
         $( this.fixture ).remove();
     }
 });


### PR DESCRIPTION
* Grunt 1 did not have any user-facing changes that affected this project, except that grunt plugins (for qunit and jshint) need updating for internal API changes.

  - grunt-cli is no longer needed as grunt now includes a CLI command for direct use in 'npm test' scripts.

  - grunt-contrib-jshint remains compatible.

  - grunt-git-authors remains compatible.

  - grunt-contrib-qunit now uses Headless Chrome via Puppeteer instead of PhantomJS. This works the same as before on bare metal of a VM, but requires the --no-sandbox option to work in isolated Docker containers.

* QUnit 2 removed support for the deprecated `setup` and `after` hooks. These were renamed to 'beforeEach' and `afterEach` in QUnit 1.16.
  <https://qunitjs.com/upgrade-guide-2.x/>

* jQuery 3 deprecated `$.isArray`, assigned unconditionally to the native ES5 `Array.isArray`. The alias will likely be removed in a future release.

I've also changed `jquery` to load from npm instead of from a live URL, so that this repo works offline or in secure developer environment where network access is not (continously) allowed.

And I've updated the test matrix to currently supported Node.js versions as older versions were no longer supported by Node, Grunt, and QUnit. <https://github.com/nodejs/Release#end-of-life-releases>